### PR TITLE
Add BLE home page and menu skeleton

### DIFF
--- a/FlutterApp/README.md
+++ b/FlutterApp/README.md
@@ -17,3 +17,4 @@ Cette application Flutter affiche en temps réel les données envoyées en Bluet
    ```
 
 La page principale montre la pression, la vitesse et jusqu'à six débitmètres. Un bouton permet de simuler la réception d'une trame JSON.
+La page "Connexion" dispose d'un bouton de scan pour rechercher les modules Bluetooth à proximité.

--- a/FlutterApp/README.md
+++ b/FlutterApp/README.md
@@ -1,0 +1,19 @@
+# Flutter Débitdouille
+
+Cette application Flutter affiche en temps réel les données envoyées en Bluetooth par le module ESP32 "Débitdouille". Un thème sombre est utilisé et plusieurs pages (connexion, calibration et réglages) sont disponibles via le menu.
+
+## Prérequis
+- [Flutter](https://docs.flutter.dev/get-started/install) doit être installé sur votre machine.
+
+## Installation
+1. Ouvrir un terminal dans ce dossier.
+2. Récupérer les dépendances :
+   ```
+   flutter pub get
+   ```
+3. Lancer l'application sur un émulateur ou un appareil connecté :
+   ```
+   flutter run
+   ```
+
+La page principale montre la pression, la vitesse et jusqu'à six débitmètres. Un bouton permet de simuler la réception d'une trame JSON.

--- a/FlutterApp/lib/main.dart
+++ b/FlutterApp/lib/main.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import 'pages/home_page.dart';
+import 'pages/connection_page.dart';
+import 'pages/calibration_page.dart';
+import 'pages/settings_page.dart';
+
+void main() {
+  runApp(const DebitdouilleApp());
+}
+
+class DebitdouilleApp extends StatelessWidget {
+  const DebitdouilleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Débitdouille',
+      theme: ThemeData.dark(),
+      routes: {
+        '/': (context) => const HomePage(),
+        '/connect': (context) => const ConnectionPage(),
+        '/calibrate': (context) => const CalibrationPage(),
+        '/settings': (context) => const SettingsPage(),
+      },
+      initialRoute: '/',
+    );
+  }
+}

--- a/FlutterApp/lib/pages/calibration_page.dart
+++ b/FlutterApp/lib/pages/calibration_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class CalibrationPage extends StatelessWidget {
+  const CalibrationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Calibrer les capteurs')),
+      body: const Center(
+        child: Text('Page de calibration à implémenter'),
+      ),
+    );
+  }
+}

--- a/FlutterApp/lib/pages/connection_page.dart
+++ b/FlutterApp/lib/pages/connection_page.dart
@@ -1,14 +1,67 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_blue/flutter_blue.dart';
 
-class ConnectionPage extends StatelessWidget {
+import '../services/bluetooth_service.dart';
+
+class ConnectionPage extends StatefulWidget {
   const ConnectionPage({super.key});
+
+  @override
+  State<ConnectionPage> createState() => _ConnectionPageState();
+}
+
+class _ConnectionPageState extends State<ConnectionPage> {
+  final List<ScanResult> _devices = [];
+  bool _scanning = false;
+
+  @override
+  void initState() {
+    super.initState();
+    BluetoothService.scanResults.listen((results) {
+      setState(() {
+        _devices
+          ..clear()
+          ..addAll(results);
+      });
+    });
+  }
+
+  Future<void> _scan() async {
+    setState(() => _scanning = true);
+    await BluetoothService.startScan();
+    await Future.delayed(const Duration(seconds: 4));
+    await BluetoothService.stopScan();
+    setState(() => _scanning = false);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Connexion')),
-      body: const Center(
-        child: Text('Fonctionnalités de connexion BLE ici'),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton(
+              onPressed: _scanning ? null : _scan,
+              child: Text(_scanning ? 'Scan en cours...' : 'Scanner'),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _devices.length,
+              itemBuilder: (context, index) {
+                final d = _devices[index];
+                return ListTile(
+                  title: Text(d.device.name.isNotEmpty
+                      ? d.device.name
+                      : d.device.id.id),
+                  subtitle: Text(d.rssi.toString()),
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/FlutterApp/lib/pages/connection_page.dart
+++ b/FlutterApp/lib/pages/connection_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class ConnectionPage extends StatelessWidget {
+  const ConnectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Connexion')),
+      body: const Center(
+        child: Text('Fonctionnalités de connexion BLE ici'),
+      ),
+    );
+  }
+}

--- a/FlutterApp/lib/pages/home_page.dart
+++ b/FlutterApp/lib/pages/home_page.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../services/bluetooth_service.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  Map<String, double> data = {
+    'P': 0,
+    'DG1': 0,
+    'DD1': 0,
+    'DG2': 0,
+    'DD2': 0,
+    'DG3': 0,
+    'DD3': 0,
+    'V': 0,
+  };
+  bool ledOn = false;
+  Timer? timeoutTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    BluetoothService.onDataReceived.listen(_onData);
+  }
+
+  void _onData(String jsonStr) {
+    try {
+      final Map<String, dynamic> map = json.decode(jsonStr);
+      map.forEach((k, v) {
+        data[k] = (v as num).toDouble();
+      });
+      setState(() {
+        ledOn = true;
+      });
+      timeoutTimer?.cancel();
+      timeoutTimer = Timer(const Duration(seconds: 3), () {
+        setState(() {
+          ledOn = false;
+        });
+      });
+    } catch (_) {
+      // ignore malformed json
+    }
+  }
+
+  void _simulate() {
+    final rnd = Random();
+    final sample = jsonEncode({
+      'P': rnd.nextDouble() * 3 + 1,
+      'DG1': rnd.nextDouble() * 3,
+      'DD1': rnd.nextDouble() * 3,
+      'DG2': rnd.nextDouble() * 3,
+      'DD2': rnd.nextDouble() * 3,
+      'DG3': rnd.nextDouble() * 3,
+      'DD3': rnd.nextDouble() * 3,
+      'V': rnd.nextDouble() * 10,
+    });
+    _onData(sample);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textStyle = Theme.of(context).textTheme.headline4!.copyWith(color: Colors.white);
+
+    final List<Widget> left = [];
+    final List<Widget> right = [];
+    for (var i = 1; i <= 3; i++) {
+      final g = data['DG$i']!;
+      final d = data['DD$i']!;
+      if (g > 0 || d > 0) {
+        left.add(Text('DG$i: ${g.toStringAsFixed(2)}', style: textStyle));
+        right.add(Text('DD$i: ${d.toStringAsFixed(2)}', style: textStyle));
+      }
+    }
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        title: const Text('Débitdouille'),
+        backgroundColor: Colors.black,
+        actions: [
+          Builder(
+            builder: (context) => IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () => Scaffold.of(context).openEndDrawer(),
+            ),
+          )
+        ],
+      ),
+      endDrawer: Drawer(
+        child: ListView(
+          children: [
+            ListTile(
+              title: const Text('Connexion'),
+              onTap: () => Navigator.of(context).pushNamed('/connect'),
+            ),
+            ListTile(
+              title: const Text('Calibrer les capteurs'),
+              onTap: () => Navigator.of(context).pushNamed('/calibrate'),
+            ),
+            ListTile(
+              title: const Text('Réglages'),
+              onTap: () => Navigator.of(context).pushNamed('/settings'),
+            ),
+          ],
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.circle,
+                    color: ledOn ? Colors.green : Colors.grey),
+                const SizedBox(width: 8),
+                Text('P: ${data['P']!.toStringAsFixed(2)}', style: textStyle),
+              ],
+            ),
+            const Spacer(),
+            Row(
+              children: [
+                Expanded(
+                    child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: left,
+                )),
+                Expanded(
+                    child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: right,
+                )),
+              ],
+            ),
+            const Spacer(),
+            Align(
+                alignment: Alignment.center,
+                child: Text('V: ${data['V']!.toStringAsFixed(1)}',
+                    style: textStyle)),
+            const SizedBox(height: 8),
+            Text(jsonEncode(data),
+                style: const TextStyle(color: Colors.white),
+                textAlign: TextAlign.center),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _simulate,
+        child: const Icon(Icons.bug_report),
+      ),
+    );
+  }
+}
+

--- a/FlutterApp/lib/pages/settings_page.dart
+++ b/FlutterApp/lib/pages/settings_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key});
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  int meters = 2;
+  bool showSimButton = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      meters = prefs.getInt('meters') ?? 2;
+      showSimButton = prefs.getBool('showSim') ?? false;
+    });
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('meters', meters);
+    await prefs.setBool('showSim', showSimButton);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Réglages')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            DropdownButton<int>(
+              value: meters,
+              dropdownColor: Colors.black,
+              items: const [
+                DropdownMenuItem(value: 2, child: Text('2 débitmètres')),
+                DropdownMenuItem(value: 4, child: Text('4 débitmètres')),
+                DropdownMenuItem(value: 6, child: Text('6 débitmètres')),
+              ],
+              onChanged: (v) {
+                if (v != null) {
+                  setState(() => meters = v);
+                  _save();
+                }
+              },
+            ),
+            SwitchListTile(
+              title: const Text('Afficher le bouton de simulation'),
+              value: showSimButton,
+              onChanged: (v) {
+                setState(() => showSimButton = v);
+                _save();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/FlutterApp/lib/services/bluetooth_service.dart
+++ b/FlutterApp/lib/services/bluetooth_service.dart
@@ -1,15 +1,30 @@
 import 'dart:async';
 
+import 'package:flutter_blue/flutter_blue.dart';
+
 class BluetoothService {
   static final StreamController<String> _controller =
       StreamController<String>.broadcast();
 
+  static final FlutterBlue _flutterBlue = FlutterBlue.instance;
+
   /// Stream of raw JSON frames received from the device.
   static Stream<String> get onDataReceived => _controller.stream;
+
+  /// Stream of scan results when scanning for BLE devices.
+  static Stream<List<ScanResult>> get scanResults => _flutterBlue.scanResults;
 
   /// Simulate receiving a frame for testing.
   static void simulateReceive(String data) {
     _controller.add(data);
+  }
+
+  static Future<void> startScan() async {
+    await _flutterBlue.startScan(timeout: const Duration(seconds: 4));
+  }
+
+  static Future<void> stopScan() async {
+    await _flutterBlue.stopScan();
   }
 
   static Future<void> connect() async {

--- a/FlutterApp/lib/services/bluetooth_service.dart
+++ b/FlutterApp/lib/services/bluetooth_service.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+class BluetoothService {
+  static final StreamController<String> _controller =
+      StreamController<String>.broadcast();
+
+  /// Stream of raw JSON frames received from the device.
+  static Stream<String> get onDataReceived => _controller.stream;
+
+  /// Simulate receiving a frame for testing.
+  static void simulateReceive(String data) {
+    _controller.add(data);
+  }
+
+  static Future<void> connect() async {
+    // TODO: implement real BLE connection using flutter_blue
+  }
+
+  static Future<void> disconnect() async {
+    // TODO: implement disconnect
+  }
+}

--- a/FlutterApp/pubspec.yaml
+++ b/FlutterApp/pubspec.yaml
@@ -1,0 +1,22 @@
+name: debitdouille_flutter
+description: Flutter rewrite of the Debitdouille mobile app
+publish_to: none
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  flutter_blue: ^0.8.0
+  shared_preferences: ^2.2.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- implement main.dart routing and dark theme
- add BLE home page displaying JSON frame
- add pages for connection, calibration and settings
- provide simple Bluetooth service
- document new features in README
- add shared_preferences dependency

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841c06ca9508320975bb61f6cb83be9