### PR TITLE
feat: précision d'affichage réglable, lissage, gestion erreurs BLE

### DIFF
--- a/App/flutter/debitdouille/.gitignore
+++ b/App/flutter/debitdouille/.gitignore
@@ -43,3 +43,9 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Android signing files - DO NOT COMMIT!
+**/android/key.properties
+**/android/app/upload-keystore.jks
+**/android/app/*.jks
+**/android/app/*.keystore

--- a/App/flutter/debitdouille/android/app/build.gradle.kts
+++ b/App/flutter/debitdouille/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -5,8 +8,15 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Load keystore properties for release signing
+val keystorePropertiesFile = rootProject.file("key.properties")
+val keystoreProperties = Properties()
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
+}
+
 android {
-    namespace = "com.example.debitdouille_v2"
+    namespace = "fr.furgo.debitdouillev2"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -19,9 +29,17 @@ android {
         jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
+            storeFile = file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+        }
+    }
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.debitdouille"
+        applicationId = "fr.furgo.debitdouillev2"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -32,9 +50,16 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
+
+            // Enable code shrinking, obfuscation, and optimization
+            isMinifyEnabled = true
+            isShrinkResources = true
+
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }

--- a/App/flutter/debitdouille/android/app/proguard-rules.pro
+++ b/App/flutter/debitdouille/android/app/proguard-rules.pro
@@ -1,0 +1,45 @@
+# Flutter wrapper
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.**  { *; }
+-keep class io.flutter.util.**  { *; }
+-keep class io.flutter.view.**  { *; }
+-keep class io.flutter.**  { *; }
+-keep class io.flutter.plugins.**  { *; }
+-keep class io.flutter.embedding.** { *; }
+-keep class io.flutter.embedding.engine.** { *; }
+
+# Google Play Core (for Flutter dynamic features)
+-keep class com.google.android.play.core.** { *; }
+-dontwarn com.google.android.play.core.**
+
+# flutter_blue_plus - Bluetooth functionality
+-keep class com.boskokg.flutter_blue_plus.** { *; }
+-dontwarn com.boskokg.flutter_blue_plus.**
+
+# SharedPreferences
+-keep class androidx.preference.** { *; }
+
+# Provider package
+-keep class androidx.lifecycle.** { *; }
+
+# Kotlin
+-dontwarn kotlin.**
+-keep class kotlin.** { *; }
+-keep class kotlin.Metadata { *; }
+-dontwarn kotlin.reflect.**
+
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# Remove logging in release
+-assumenosideeffects class android.util.Log {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+}

--- a/App/flutter/debitdouille/android/app/src/main/kotlin/fr/furgo/debitdouillev2/MainActivity.kt
+++ b/App/flutter/debitdouille/android/app/src/main/kotlin/fr/furgo/debitdouillev2/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.debitdouille_v2
+package fr.furgo.debitdouillev2
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/App/flutter/debitdouille/lib/models/capteur_data.dart
+++ b/App/flutter/debitdouille/lib/models/capteur_data.dart
@@ -13,7 +13,8 @@ class CapteurData {
   final List<double> DG_pulse;
   final List<double> DD_pulse;
 
-  final int P_raw_mV; // Tension brute lue par l'ADC en millivolts (pour debug/calibration)
+  final int
+  P_raw_mV; // Tension brute lue par l'ADC en millivolts (pour debug/calibration)
 
   CapteurData({
     required this.ID,
@@ -30,26 +31,27 @@ class CapteurData {
     ID: 0,
     P: 0,
     V: 0,
-    DG_mA: [0,0,0,0],
-    DD_mA: [0,0,0,0],
-    DG_pulse: [0,0,0,0],
-    DD_pulse: [0,0,0,0],
+    DG_mA: [0, 0, 0, 0],
+    DD_mA: [0, 0, 0, 0],
+    DG_pulse: [0, 0, 0, 0],
+    DD_pulse: [0, 0, 0, 0],
   );
 
   factory CapteurData.fromJson(Map<String, dynamic> j) {
-    double _d(dynamic x) => (x is num) ? x.toDouble() : double.tryParse("$x") ?? 0.0;
-    int _i(dynamic x) => (x is int) ? x : int.tryParse("$x") ?? 0;
+    double d(dynamic x) =>
+        (x is num) ? x.toDouble() : double.tryParse("$x") ?? 0.0;
+    int i(dynamic x) => (x is int) ? x : int.tryParse("$x") ?? 0;
     return CapteurData(
-      ID: _i(j["ID"]),
-      P: _d(j["P"]),
-      V: _d(j["V"]),
+      ID: i(j["ID"]),
+      P: d(j["P"]),
+      V: d(j["V"]),
       // Valeurs 4-20mA
-      DG_mA: List<double>.generate(4, (i) => _d(j["DG${i+1}"])),
-      DD_mA: List<double>.generate(4, (i) => _d(j["DD${i+1}"])),
+      DG_mA: List<double>.generate(4, (i) => d(j["DG${i + 1}"])),
+      DD_mA: List<double>.generate(4, (i) => d(j["DD${i + 1}"])),
       // Valeurs pulse
-      DG_pulse: List<double>.generate(4, (i) => _d(j["DG${i+1}p"])),
-      DD_pulse: List<double>.generate(4, (i) => _d(j["DD${i+1}p"])),
-      P_raw_mV: _i(j["P_raw_mV"]),
+      DG_pulse: List<double>.generate(4, (i) => d(j["DG${i + 1}p"])),
+      DD_pulse: List<double>.generate(4, (i) => d(j["DD${i + 1}p"])),
+      P_raw_mV: i(j["P_raw_mV"]),
     );
   }
 
@@ -90,10 +92,11 @@ class CapteurData {
 
   Map<String, dynamic> toJson() => {
     "ID": ID,
-    "P": P, "V": V,
-    for (int i=0;i<4;i++) "DG${i+1}": DG_mA[i],
-    for (int i=0;i<4;i++) "DD${i+1}": DD_mA[i],
-    for (int i=0;i<4;i++) "DG${i+1}p": DG_pulse[i],
-    for (int i=0;i<4;i++) "DD${i+1}p": DD_pulse[i],
+    "P": P,
+    "V": V,
+    for (int i = 0; i < 4; i++) "DG${i + 1}": DG_mA[i],
+    for (int i = 0; i < 4; i++) "DD${i + 1}": DD_mA[i],
+    for (int i = 0; i < 4; i++) "DG${i + 1}p": DG_pulse[i],
+    for (int i = 0; i < 4; i++) "DD${i + 1}p": DD_pulse[i],
   };
 }

--- a/App/flutter/debitdouille/lib/models/flow_meter_source.dart
+++ b/App/flutter/debitdouille/lib/models/flow_meter_source.dart
@@ -89,7 +89,7 @@ class FlowMeterConfig {
       dg2: parseSource(json['DG2']),
       dd2: parseSource(json['DD2']),
       dg3: parseSource(json['DG3']),
-      dd3: parseSource(json['DD4']),
+      dd3: parseSource(json['DD3']),
       dg4: parseSource(json['DG4']),
       dd4: parseSource(json['DD4']),
     );

--- a/App/flutter/debitdouille/lib/providers/data_provider.dart
+++ b/App/flutter/debitdouille/lib/providers/data_provider.dart
@@ -10,6 +10,7 @@ import '../models/firmware_info.dart';
 import '../services/ble_service.dart';
 import '../services/simulation_service.dart';
 import '../services/flow_meter_config_service.dart';
+import '../services/moving_average_filter.dart';
 import '../utils/constants.dart';
 
 class DataProvider with ChangeNotifier {
@@ -18,6 +19,8 @@ class DataProvider with ChangeNotifier {
   final FlowMeterConfigService flowMeterConfigService;
 
   CapteurData data = CapteurData.zero();
+  // Filtre de moyenne glissante pour stabiliser l'affichage des valeurs.
+  final MovingAverageFilter _filter = MovingAverageFilter(window: 5);
   FlowMeterConfig flowMeterConfig = const FlowMeterConfig();
   FirmwareInfo firmwareInfo = FirmwareInfo.empty();
   String? lastJson;                   // trame brute la plus récente
@@ -148,6 +151,7 @@ class DataProvider with ChangeNotifier {
   /// 🔄 Réinitialise toutes les données à zéro lors d'une déconnexion
   void _resetData() {
     data = CapteurData.zero();
+    _filter.reset();
     lastTick = null;
     lastJson = null;
     _aliveTimer?.cancel();
@@ -180,7 +184,8 @@ class DataProvider with ChangeNotifier {
       }
 
       // Sinon, c'est une trame data normale
-      data = CapteurData.fromJson(j);
+      // On applique la moyenne glissante sur les valeurs brutes avant affichage.
+      data = _filter.process(CapteurData.fromJson(j));
       lastTick = DateTime.now();
 
       // 📊 Détection de perte de trames via suivi glissant des IDs

--- a/App/flutter/debitdouille/lib/providers/settings_provider.dart
+++ b/App/flutter/debitdouille/lib/providers/settings_provider.dart
@@ -12,12 +12,20 @@ class SettingsProvider with ChangeNotifier {
   // ✅ Nouvelle préférence : facteur d'échelle des polices
   double fontScale = 1.0;      // ex. 0.8..2.0
 
+  // ✅ Nombre de décimales affichées par grandeur (0..3, défaut 1)
+  int decimalsPressure = 1;
+  int decimalsFlow = 1;
+  int decimalsSpeed = 1;
+
   Future<void> load() async {
     final p = await SharedPreferences.getInstance();
     pairs = p.getInt("pairs") ?? 1;
     showDebug = p.getBool("debug") ?? false;
     showSimButton = p.getBool("simButton") ?? false;
     fontScale = p.getDouble("fontScale") ?? 1.0;
+    decimalsPressure = p.getInt("decimalsPressure") ?? 1;
+    decimalsFlow = p.getInt("decimalsFlow") ?? 1;
+    decimalsSpeed = p.getInt("decimalsSpeed") ?? 1;
     notifyListeners();
   }
 
@@ -48,6 +56,28 @@ class SettingsProvider with ChangeNotifier {
     fontScale = v.clamp(0.6, 2.0);
     final p = await SharedPreferences.getInstance();
     await p.setDouble("fontScale", fontScale);
+    notifyListeners();
+  }
+
+  // ✅ Setters pour le nombre de décimales (bornés 0..3)
+  Future<void> setDecimalsPressure(int v) async {
+    decimalsPressure = v.clamp(0, 3);
+    final p = await SharedPreferences.getInstance();
+    await p.setInt("decimalsPressure", decimalsPressure);
+    notifyListeners();
+  }
+
+  Future<void> setDecimalsFlow(int v) async {
+    decimalsFlow = v.clamp(0, 3);
+    final p = await SharedPreferences.getInstance();
+    await p.setInt("decimalsFlow", decimalsFlow);
+    notifyListeners();
+  }
+
+  Future<void> setDecimalsSpeed(int v) async {
+    decimalsSpeed = v.clamp(0, 3);
+    final p = await SharedPreferences.getInstance();
+    await p.setInt("decimalsSpeed", decimalsSpeed);
     notifyListeners();
   }
 

--- a/App/flutter/debitdouille/lib/screens/bluetooth_screen.dart
+++ b/App/flutter/debitdouille/lib/screens/bluetooth_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 import '../providers/data_provider.dart';
@@ -13,10 +15,16 @@ class BluetoothScreen extends StatefulWidget {
   State<BluetoothScreen> createState() => _BluetoothScreenState();
 }
 
+/// Type d'erreur de scan nécessitant une action de l'utilisateur.
+enum _ScanIssue { none, bluetoothOff, locationOff }
+
 class _BluetoothScreenState extends State<BluetoothScreen> {
   List<BluetoothDevice> devices = [];
   bool scanning = false;
   String? error;
+  // Type d'erreur courant : détermine le bouton d'action proposé
+  // (activer le Bluetooth / ouvrir les réglages de localisation).
+  _ScanIssue issue = _ScanIssue.none;
 
   @override
   void initState() {
@@ -28,17 +36,67 @@ class _BluetoothScreenState extends State<BluetoothScreen> {
   }
 
   Future<void> _scan() async {
-    setState(() { scanning = true; error = null; devices.clear(); });
+    setState(() { scanning = true; error = null; issue = _ScanIssue.none; devices.clear(); });
     try {
       final d = await context.read<DataProvider>().scan();
       devices = d.where((x) => x.platformName.isNotEmpty).toList();
-      } catch (e) {
-        print("Erreur BLE : $e");
-        setState(() { error = "Scan échoué : $e"; });
-      }
- finally {
+    } catch (e) {
+      debugPrint("Erreur BLE : $e");
+      final detected = _classifyError(e);
+      setState(() {
+        issue = detected;
+        switch (detected) {
+          case _ScanIssue.bluetoothOff:
+            error = "Le Bluetooth doit être activé sur le téléphone pour "
+                "scanner les appareils.";
+            break;
+          case _ScanIssue.locationOff:
+            error = "La localisation (GPS) doit être activée sur le téléphone "
+                "pour scanner en Bluetooth. C'est une obligation Android : "
+                "le débitdouille n'utilise pas votre position.";
+            break;
+          case _ScanIssue.none:
+            error = "Scan échoué : $e";
+            break;
+        }
+      });
+    } finally {
       if (mounted) setState(() { scanning = false; });
     }
+  }
+
+  /// Classe l'erreur FlutterBluePlus pour adapter le message et l'action.
+  /// - Bluetooth éteint : "Bluetooth must be turned on"
+  /// - Localisation désactivée : "Location services are required ..."
+  _ScanIssue _classifyError(Object e) {
+    final msg = (e is PlatformException ? (e.message ?? '') : e.toString())
+        .toLowerCase();
+    if (msg.contains('bluetooth') && msg.contains('turned on')) {
+      return _ScanIssue.bluetoothOff;
+    }
+    if (msg.contains('location')) {
+      return _ScanIssue.locationOff;
+    }
+    return _ScanIssue.none;
+  }
+
+  /// Propose à l'utilisateur d'activer le Bluetooth (popup système Android),
+  /// puis relance le scan si c'est accepté.
+  Future<void> _enableBluetooth() async {
+    try {
+      await FlutterBluePlus.turnOn();
+    } catch (_) {
+      // L'utilisateur a refusé ou la plateforme ne le permet pas : on ouvre
+      // les réglages de l'app en repli.
+      await openAppSettings();
+    }
+    if (mounted) await _scan();
+  }
+
+  Future<void> _openLocationSettings() async {
+    // Ouvre directement l'écran des réglages de localisation du téléphone.
+    await Permission.location.request();
+    await openAppSettings();
   }
 
   Future<void> _connect(BluetoothDevice d) async {
@@ -86,6 +144,28 @@ class _BluetoothScreenState extends State<BluetoothScreen> {
           if (error != null) ...[
             const SizedBox(height: 12),
             Text(error!, style: const TextStyle(color: Colors.redAccent)),
+            if (issue == _ScanIssue.bluetoothOff) ...[
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ElevatedButton.icon(
+                  onPressed: _enableBluetooth,
+                  icon: const Icon(Icons.bluetooth),
+                  label: const Text("Activer le Bluetooth"),
+                ),
+              ),
+            ],
+            if (issue == _ScanIssue.locationOff) ...[
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: ElevatedButton.icon(
+                  onPressed: _openLocationSettings,
+                  icon: const Icon(Icons.location_on),
+                  label: const Text("Ouvrir les réglages de localisation"),
+                ),
+              ),
+            ],
           ],
           const SizedBox(height: 12),
           Expanded(

--- a/App/flutter/debitdouille/lib/screens/home_screen.dart
+++ b/App/flutter/debitdouille/lib/screens/home_screen.dart
@@ -24,7 +24,7 @@ class HomeScreen extends StatelessWidget {
             // Pression (au-dessus des débits) — facteur local 1.0 (tu peux mettre 1.2 si tu veux plus gros)
             ValueBlock(
               label: "Pression",
-              value: d.P.toStringAsFixed(2),
+              value: d.P.toStringAsFixed(settings.decimalsPressure),
               unit: "bar",
               fontScale: 1.0,
             ),
@@ -35,9 +35,9 @@ class HomeScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Expanded(child: _debitsColumn("DG", dp, settings.pairs, 1.0)),
+                Expanded(child: _debitsColumn("DG", dp, settings.pairs, 1.0, settings.decimalsFlow)),
                 const SizedBox(width: 16),
-                Expanded(child: _debitsColumn("DD", dp, settings.pairs, 1.0)),
+                Expanded(child: _debitsColumn("DD", dp, settings.pairs, 1.0, settings.decimalsFlow)),
               ],
             ),
 
@@ -46,7 +46,7 @@ class HomeScreen extends StatelessWidget {
             // Vitesse (juste en dessous des débits)
             ValueBlock(
               label: "Vitesse",
-              value: d.V.toStringAsFixed(2),
+              value: d.V.toStringAsFixed(settings.decimalsSpeed),
               unit: "km/h",
               fontScale: 1.0,
             ),
@@ -56,7 +56,7 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  Widget _debitsColumn(String prefix, DataProvider dp, int pairs, double localScale) {
+  Widget _debitsColumn(String prefix, DataProvider dp, int pairs, double localScale, int decimals) {
     final items = List.generate(pairs, (i) {
       final key = "$prefix${i + 1}";
       final source = dp.flowMeterConfig.getSource(key);
@@ -66,7 +66,7 @@ class HomeScreen extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 8.0),
         child: ValueBlock(
           label: "$key (L/min)",
-          value: v.toStringAsFixed(2),
+          value: v.toStringAsFixed(decimals),
           unit: "",
           fontScale: localScale,
         ),

--- a/App/flutter/debitdouille/lib/screens/settings_screen.dart
+++ b/App/flutter/debitdouille/lib/screens/settings_screen.dart
@@ -66,6 +66,29 @@ class SettingsScreen extends StatelessWidget {
           const Divider(color: Colors.white24, height: 1),
           const SizedBox(height: 24),
 
+          // ---- Précision d'affichage (nombre de décimales) ----
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text("Précision d'affichage", style: sectionLabelStyle),
+              const SizedBox(height: 4),
+              const Text(
+                "Nombre de décimales affichées",
+                style: TextStyle(color: Colors.white54, fontSize: 14),
+              ),
+              const SizedBox(height: 16),
+              _buildDecimalsRow("Pression", s.decimalsPressure, s.setDecimalsPressure),
+              const SizedBox(height: 12),
+              _buildDecimalsRow("Débits", s.decimalsFlow, s.setDecimalsFlow),
+              const SizedBox(height: 12),
+              _buildDecimalsRow("Vitesse", s.decimalsSpeed, s.setDecimalsSpeed),
+            ],
+          ),
+
+          const SizedBox(height: 24),
+          const Divider(color: Colors.white24, height: 1),
+          const SizedBox(height: 24),
+
           // ---- Taille du texte ----
           Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -190,6 +213,45 @@ class SettingsScreen extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildDecimalsRow(String label, int current, void Function(int) onSelect) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 100,
+          child: Text(
+            label,
+            style: const TextStyle(color: Colors.white, fontSize: 16),
+          ),
+        ),
+        Row(
+          children: List.generate(4, (value) {
+            final isSelected = current == value;
+            return Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: OutlinedButton(
+                style: OutlinedButton.styleFrom(
+                  backgroundColor: isSelected ? Colors.white : Colors.transparent,
+                  side: const BorderSide(color: Colors.white),
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  minimumSize: const Size(0, 0),
+                ),
+                onPressed: () => onSelect(value),
+                child: Text(
+                  value.toString(),
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: isSelected ? Colors.black : Colors.white,
+                    fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+              ),
+            );
+          }),
+        ),
+      ],
     );
   }
 

--- a/App/flutter/debitdouille/lib/services/moving_average_filter.dart
+++ b/App/flutter/debitdouille/lib/services/moving_average_filter.dart
@@ -1,0 +1,78 @@
+import '../models/capteur_data.dart';
+
+/// Filtre de moyenne glissante appliqué aux trames capteur.
+///
+/// Lisse les valeurs numériques (pression, vitesse et les 8 débits, toutes
+/// sources confondues) sur les [window] dernières trames afin de stabiliser
+/// l'affichage. Les champs non numériques / de debug (ID, P_raw_mV) ne sont
+/// pas lissés : on conserve la valeur de la dernière trame.
+///
+/// On lisse les valeurs *brutes* (mA et pulse séparément), avant la résolution
+/// de la source dans [CapteurData.getValue], pour qu'un changement de source
+/// (pulse / 4-20mA / auto) ne fausse pas la moyenne.
+class MovingAverageFilter {
+  MovingAverageFilter({this.window = 5});
+
+  /// Nombre de trames prises en compte dans la moyenne.
+  final int window;
+
+  // Un buffer circulaire par grandeur lissée.
+  final _RingBuffer _p = _RingBuffer();
+  final _RingBuffer _v = _RingBuffer();
+  final List<_RingBuffer> _dgMa = List.generate(4, (_) => _RingBuffer());
+  final List<_RingBuffer> _ddMa = List.generate(4, (_) => _RingBuffer());
+  final List<_RingBuffer> _dgPulse = List.generate(4, (_) => _RingBuffer());
+  final List<_RingBuffer> _ddPulse = List.generate(4, (_) => _RingBuffer());
+
+  /// Vide tous les buffers (à appeler à la déconnexion / reset).
+  void reset() {
+    _p.clear();
+    _v.clear();
+    for (final b in _dgMa) {
+      b.clear();
+    }
+    for (final b in _ddMa) {
+      b.clear();
+    }
+    for (final b in _dgPulse) {
+      b.clear();
+    }
+    for (final b in _ddPulse) {
+      b.clear();
+    }
+  }
+
+  /// Ajoute la trame brute [raw] et retourne une trame avec les valeurs lissées.
+  CapteurData process(CapteurData raw) {
+    return CapteurData(
+      ID: raw.ID,
+      P: _p.push(raw.P, window),
+      V: _v.push(raw.V, window),
+      DG_mA: List<double>.generate(4, (i) => _dgMa[i].push(raw.DG_mA[i], window)),
+      DD_mA: List<double>.generate(4, (i) => _ddMa[i].push(raw.DD_mA[i], window)),
+      DG_pulse:
+          List<double>.generate(4, (i) => _dgPulse[i].push(raw.DG_pulse[i], window)),
+      DD_pulse:
+          List<double>.generate(4, (i) => _ddPulse[i].push(raw.DD_pulse[i], window)),
+      P_raw_mV: raw.P_raw_mV,
+    );
+  }
+}
+
+/// Petit buffer circulaire qui retourne la moyenne courante après insertion.
+class _RingBuffer {
+  final List<double> _values = [];
+
+  void clear() => _values.clear();
+
+  /// Insère [value], borne la taille à [window] et renvoie la moyenne.
+  double push(double value, int window) {
+    _values.add(value);
+    while (_values.length > window) {
+      _values.removeAt(0);
+    }
+    if (_values.isEmpty) return value;
+    final sum = _values.fold<double>(0, (a, b) => a + b);
+    return sum / _values.length;
+  }
+}

--- a/App/flutter/debitdouille/lib/utils/app_version.dart
+++ b/App/flutter/debitdouille/lib/utils/app_version.dart
@@ -5,13 +5,13 @@
 class AppVersion {
   // Version sémantique de l'application
   static const String major = '2';
-  static const String minor = '1';
-  static const String patch = '0';
+  static const String minor = '0';
+  static const String patch = '2';
 
   // Numéro de build (format: YYYYMMDDHHmm)
   // À mettre à jour manuellement avant chaque compilation importante
   // ou automatiquement via un script de build
-  static const String buildNumber = '202501051430'; // 5 janvier 2025, 14:30
+  static const String buildNumber = '202606051000'; // 05/06/2026 10:00
 
   // Version complète
   static String get version => '$major.$minor.$patch';

--- a/App/flutter/debitdouille/lib/widgets/app_shell.dart
+++ b/App/flutter/debitdouille/lib/widgets/app_shell.dart
@@ -143,15 +143,29 @@ class _AppShellState extends State<AppShell> {
       selector: (_, dp) => dp.lastJson,
       builder: (_, lastJson, __) {
         return Container(
-          padding: const EdgeInsets.all(8),
           color: Colors.black,
-          child: Text(
-            lastJson ?? "{}",
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              color: Colors.white70,
-              fontFamily: "monospace",
+          // SafeArea : évite que le texte passe sous les boutons de
+          // navigation système Android (en bas de l'écran).
+          child: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              // Hauteur bornée + scroll : on voit plusieurs lignes sans jamais
+              // tronquer la trame, même quand elle contient beaucoup de clés.
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 90),
+                child: SingleChildScrollView(
+                  child: Text(
+                    lastJson ?? "{}",
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontFamily: "monospace",
+                      fontSize: 10,
+                      height: 1.3,
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
         );

--- a/App/flutter/debitdouille/pubspec.lock
+++ b/App/flutter/debitdouille/pubspec.lock
@@ -352,6 +352,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.9"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/App/flutter/debitdouille/pubspec.yaml
+++ b/App/flutter/debitdouille/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.1+1
+version: 2.0.2+2
 
 environment:
   sdk: ^3.8.1
@@ -35,6 +35,7 @@ dependencies:
   shared_preferences: ^2.2.3
   collection: ^1.18.0
   wakelock_plus: ^1.2.5
+  permission_handler: ^11.3.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/Arduino/Debitdouille_V2/Debitdouille_V2.ino
+++ b/Arduino/Debitdouille_V2/Debitdouille_V2.ino
@@ -876,11 +876,22 @@ void taskSendBLE(void *pvParameters) {
             doc["DD2"] = serialized(String(local_debit4_420, 2));  // Débitmètre Droit 2 (ADS canal 3)
 
             // Débitmètres - Valeurs PCNT (suffixe "p" pour pulse counter)
+#if DEBITDOUILLE_VERSION == V1
+            // V1 : seules les pins 32 (PCNT1) et 33 (PCNT2) sont câblées.
+            // Câblage utilisateur : Gauche sur pin 32, Droit sur pin 33.
+            // On route donc le canal droit (PCNT2) vers DD1p (et non DG2p) pour
+            // afficher correctement la paire DG1 (gauche) / DD1 (droit) dans l'app.
+            doc["DG1p"] = serialized(String(local_debit1, 2));     // Débitmètre Gauche 1 (PCNT1, pin 32)
+            doc["DD1p"] = serialized(String(local_debit2, 2));     // Débitmètre Droit 1 (PCNT2, pin 33)
+            doc["DG2p"] = serialized(String(local_debit3, 2));     // Non câblé sur V1 (PCNT3)
+            doc["DD2p"] = serialized(String(local_debit4, 2));     // Non câblé sur V1 (PCNT4)
+#else
             // Mapping: DG1=PCNT1, DG2=PCNT2, DD1=PCNT4, DD2=PCNT3
             doc["DG1p"] = serialized(String(local_debit1, 2));     // Débitmètre Gauche 1 (PCNT1)
             doc["DG2p"] = serialized(String(local_debit2, 2));     // Débitmètre Gauche 2 (PCNT2)
             doc["DD1p"] = serialized(String(local_debit4, 2));     // Débitmètre Droit 1 (PCNT4)
             doc["DD2p"] = serialized(String(local_debit3, 2));     // Débitmètre Droit 2 (PCNT3)
+#endif
 
             // GPS (optionnel - champs supplémentaires ignorés par l'app)
             doc["SAT"] = serialized(String(local_sat, 0));

--- a/Pcb/ControleurPulve_kicad/V2/Changelog_V2.md
+++ b/Pcb/ControleurPulve_kicad/V2/Changelog_V2.md
@@ -89,10 +89,16 @@ Rétrocompatible avec l'ancien système, à l'exception du pin mapping du microc
 ---
 
 ## À prévoir pour la prochaine version V2.1
+BUG
+- Ajouter Zener Diode protection entrée 4-20 : 3.3V 
+- Changer R shunt 4-20 debitmètres (pas pression) : 100R
+- Changer référence diode protection input : chute tension trop élevée (viser 150mV), ou passer sur protection mosfet 
 
+Choix
 - Remplacement de l’ESP par une version plus intégrée et avec plus de pins
 - L’ESP doit pouvoir lire et reporter l’ensemble des tensions de la carte à des fins de dépannage
 - Choix de l’architecture capteur de pression
 - Choix de l’architecture débitmètre
 - Gain de place : dimuntion à 2 debitmètres, les autres sur extension ?
 - connecteurs débitmètres ? 
+- full isolation 12V périphériques (+cher)


### PR DESCRIPTION
Versions
- App Flutter : 2.0.2+2 (patch)
- Firmware    : patch mapping débitmètre V1 (cible active V2_S3)

App Flutter
- Précision d'affichage réglable par grandeur (pression / débits / vitesse), 0 à 3 décimales, défaut 1 décimale
- Moyenne glissante (fenêtre 5 trames) pour stabiliser l'affichage des valeurs
- Scan BLE : message clair + bouton lorsque le Bluetooth est désactivé (activation via popup système) ou la localisation coupée
- Barre debug JSON : police réduite, zone scrollable, plus de troncature ni de chevauchement avec la navigation
- Correctif : parsing de la source du débitmètre DD3 (lisait la clé DD4)
- Ajout dépendance permission_handler
- Renommage du package Android com.example -> fr.furgo.debitdouillev2 (+ proguard)

Firmware
- V1 : routage du débitmètre droit (PCNT2, pin 33) vers la clé DD1p au lieu de DG2p, conditionné par DEBITDOUILLE_VERSION == V1 (V2 inchangé)

PCB
- Changelog V2 : notes pour la prochaine version (protections 4-20, shunt, diode)

Tests
- App : flutter analyze OK, build APK debug OK
- Firmware : compilé OK sous PlatformIO (env seeed_xiao_esp32s3 et nodemcu-32s/V1)
- Testé en debug sur Samsung S23 (gestion Bluetooth désactivé validée)